### PR TITLE
feat: add operator tokens for lexical analysis

### DIFF
--- a/src/main/cup/chocopy/pa1/ChocoPy.cup
+++ b/src/main/cup/chocopy/pa1/ChocoPy.cup
@@ -143,11 +143,37 @@ action code {:
  * in actions ( {: ... :} ).
  */
 terminal NEWLINE;
-terminal String PLUS; 
-terminal Integer NUMBER; 
 /* Returned by the lexer for erroneous tokens.  Since it does not appear in
  * the grammar, it indicates a syntax error. */
 terminal UNRECOGNIZED;   
+
+/* Literals. */
+terminal Integer NUMBER; 
+
+/* Operators. */
+terminal String PLUS; 
+terminal String MINUS;
+terminal String TIMES;
+terminal String INTEGER_DIVISION;
+terminal String MOD;
+terminal String LESS_THAN;
+terminal String GREATER_THAN;
+terminal String LESS_OR_EQUAL_THAN;
+terminal String GREATER_OR_EQUAL_THAN;
+terminal String EQUALS;
+terminal String NOT_EQUALS;
+terminal String ASSIGN;
+terminal String LEFT_PARENTHESIS;
+terminal String RIGHT_PARENTHESIS;
+terminal String LEFT_BRACKET;
+terminal String RIGHT_BRACKET;
+terminal String COMMA;
+terminal String COLON;
+terminal String DOT;
+terminal String RIGHT_ARROW;
+
+/* Identifiers. */
+terminal String IDENTIFIER;
 
 /* Nonterminal symbols (defined in production rules below).
  * As for terminal symbols, 

--- a/src/main/jflex/chocopy/pa1/ChocoPy.jflex
+++ b/src/main/jflex/chocopy/pa1/ChocoPy.jflex
@@ -57,6 +57,8 @@ LineBreak  = \r|\n|\r\n
 
 IntegerLiteral = 0 | [1-9][0-9]*
 
+Identifier = [a-zA-Z_][a-zA-Z_0-9]*
+
 %%
 
 
@@ -70,7 +72,32 @@ IntegerLiteral = 0 | [1-9][0-9]*
                                                  Integer.parseInt(yytext())); }
 
   /* Operators. */
+  /* The following is a space-separated list of symbols that correspond to distinct ChocoPy tokens: 
+   + - * // % < > <= >= == != = ( ) [ ] , : . -> */
+
   "+"                         { return symbol(ChocoPyTokens.PLUS, yytext()); }
+  "-"                         { return symbol(ChocoPyTokens.MINUS, yytext()); }
+  "*"                         { return symbol(ChocoPyTokens.TIMES, yytext()); }
+  "//"                        { return symbol(ChocoPyTokens.INTEGER_DIVISION, yytext()); }
+  "%"                         { return symbol(ChocoPyTokens.MOD, yytext()); }
+  "<"                         { return symbol(ChocoPyTokens.LESS_THAN, yytext()); }
+  ">"                         { return symbol(ChocoPyTokens.GREATER_THAN, yytext()); }
+  "<="                        { return symbol(ChocoPyTokens.LESS_OR_EQUAL_THAN, yytext()); }
+  ">="                        { return symbol(ChocoPyTokens.GREATER_OR_EQUAL_THAN, yytext()); }
+  "=="                        { return symbol(ChocoPyTokens.EQUALS, yytext()); }
+  "!="                        { return symbol(ChocoPyTokens.NOT_EQUALS, yytext()); }
+  "="                         { return symbol(ChocoPyTokens.ASSIGN, yytext()); }
+  "("                         { return symbol(ChocoPyTokens.LEFT_PARENTHESIS, yytext()); }
+  ")"                         { return symbol(ChocoPyTokens.RIGHT_PARENTHESIS, yytext()); }
+  "["                         { return symbol(ChocoPyTokens.LEFT_BRACKET, yytext()); }
+  "]"                         { return symbol(ChocoPyTokens.RIGHT_BRACKET, yytext()); }
+  ","                         { return symbol(ChocoPyTokens.COMMA, yytext()); }
+  ":"                         { return symbol(ChocoPyTokens.COLON, yytext()); }
+  "."                         { return symbol(ChocoPyTokens.DOT, yytext()); }
+  "->"                        { return symbol(ChocoPyTokens.RIGHT_ARROW, yytext()); }
+
+  /* Identifiers. */
+ {Identifier}                 { return symbol(ChocoPyTokens.IDENTIFIER, yytext()); }
 
   /* Whitespace. */
   {WhiteSpace}                { /* ignore */ }

--- a/src/test/data/pa1/sample/operators_identifiers_test.py
+++ b/src/test/data/pa1/sample/operators_identifiers_test.py
@@ -1,0 +1,5 @@
+a + b - c * d // e % f
+y < z > w <= u >= v == m != n
+x.val = A
+func(a: type_var, b: type_var) -> return_type
+my_list[i] = _x2Aa_89Zb


### PR DESCRIPTION
Adding operator and identifier tokens. Creating a test file called operators_identifiers_test.py that tests the lexer's ability to recognize the defined tokens.