### PR TITLE
Tokens de <idstring> e <string>

### DIFF
--- a/src/main/cup/chocopy/pa1/ChocoPy.cup
+++ b/src/main/cup/chocopy/pa1/ChocoPy.cup
@@ -149,6 +149,7 @@ terminal UNRECOGNIZED;
 
 /* Literals. */
 terminal Integer NUMBER; 
+terminal String IDSTRING;
 
 /* Operators. */
 terminal String PLUS; 

--- a/src/main/cup/chocopy/pa1/ChocoPy.cup
+++ b/src/main/cup/chocopy/pa1/ChocoPy.cup
@@ -150,6 +150,7 @@ terminal UNRECOGNIZED;
 /* Literals. */
 terminal Integer NUMBER; 
 terminal String IDSTRING;
+terminal String STRING;
 
 /* Operators. */
 terminal String PLUS; 

--- a/src/main/jflex/chocopy/pa1/ChocoPy.jflex
+++ b/src/main/jflex/chocopy/pa1/ChocoPy.jflex
@@ -58,10 +58,22 @@ LineBreak  = \r|\n|\r\n
 IntegerLiteral = 0 | [1-9][0-9]*
 
 IdStringLiteral = \"[a-zA-Z_][\w]*\"
+
+/* Macro to \", \\, \n and \r, respectively. All the escaped characters of chocopy defined with hexadecimal */
+ScapedChars = \x5c\x22|\x5c\x5c|\x5cn|\x5cr
+
+/* This Macro defines a subset of ASCII from code 32 to code 127, without double quote and backslash */
+ASCIIWithoutScapeReserved = [\x20-\x21\x23-\x5b\x5d-\x7f]
+
+StringLiteral = \"({ASCIIWithoutScapeReserved}|{ScapedChars})*\" 
+
 Identifier = [a-zA-Z_][a-zA-Z_0-9]*
 
 %%
 
+{IdStringLiteral}           {  return symbol(ChocoPyTokens.IDSTRING, yytext()); }
+
+{StringLiteral}           {  return symbol(ChocoPyTokens.STRING, yytext()); }
 
 <YYINITIAL> {
 

--- a/src/main/jflex/chocopy/pa1/ChocoPy.jflex
+++ b/src/main/jflex/chocopy/pa1/ChocoPy.jflex
@@ -60,10 +60,16 @@ IntegerLiteral = 0 | [1-9][0-9]*
 IdStringLiteral = \"[a-zA-Z_][\w]*\"
 
 /* Macro to \", \\, \n and \r, respectively. All the escaped characters of chocopy defined with hexadecimal */
-ScapedChars = \x5c\x22|\x5c\x5c|\x5cn|\x5cr
+ScapedChars = \\\"|\\\\|\\n|\\r
 
-/* This Macro defines a subset of ASCII from code 32 to code 127, without double quote and backslash */
-ASCIIWithoutScapeReserved = [\x20-\x21\x23-\x5b\x5d-\x7f]
+/* 
+    This Macro defines a subset of ASCII from code 32 to code 127, without double quote and backslash.
+    The definition include space, ! and the ranges: 
+        # to [
+        ] to DEL, 
+    ignoring the double quote and backslash.
+ */
+ASCIIWithoutScapeReserved = [ !#-\[\]-\x7f]
 
 StringLiteral = \"({ASCIIWithoutScapeReserved}|{ScapedChars})*\" 
 

--- a/src/main/jflex/chocopy/pa1/ChocoPy.jflex
+++ b/src/main/jflex/chocopy/pa1/ChocoPy.jflex
@@ -57,6 +57,7 @@ LineBreak  = \r|\n|\r\n
 
 IntegerLiteral = 0 | [1-9][0-9]*
 
+IdStringLiteral = \"[a-zA-Z_][\w]*\"
 Identifier = [a-zA-Z_][a-zA-Z_0-9]*
 
 %%

--- a/src/test/data/pa1/sample/expr_string.py
+++ b/src/test/data/pa1/sample/expr_string.py
@@ -1,0 +1,1 @@
+ "type: \" \\ \r \n" + "SomeRandomClass"

--- a/src/test/data/pa1/sample/expr_string.py
+++ b/src/test/data/pa1/sample/expr_string.py
@@ -1,1 +1,1 @@
- "type: \" \\ \r \n" + "SomeRandomClass"
+ "#Type12!!? :: \" \\ \r \n" + "SomeRandomClass"


### PR DESCRIPTION
## Mudanças

Esse PR inclui no .jflex os macros para <string> e <idstring> do chocopy, e cria seus respectivos terminais no .cup.

## Validação

Compare essa saída com o código expresso no exemplo de teste

![image](https://github.com/user-attachments/assets/d7445d45-2d25-421e-94b4-7cd9367510a3)

