### PR TITLE
Implementação da analise léxica de identações

### DIFF
--- a/src/main/cup/chocopy/pa1/ChocoPy.cup
+++ b/src/main/cup/chocopy/pa1/ChocoPy.cup
@@ -143,12 +143,15 @@ action code {:
  * in actions ( {: ... :} ).
  */
 terminal NEWLINE;
+terminal INDENT;
+terminal DEDENT;
 
 /* Errors */
 /* Returned by the lexer for erroneous tokens.  Since it does not appear in
  * the grammar, it indicates a syntax error. */
 terminal UNRECOGNIZED;   
 terminal INTEGER_OVERFLOW_LEXICAL_ERROR;
+terminal INDENTATION_ERROR;
 
 /* Keywords. */
 terminal String FALSE; 

--- a/src/test/data/pa1/own_tests/indentation.py
+++ b/src/test/data/pa1/own_tests/indentation.py
@@ -1,0 +1,13 @@
+class ForeverYoung:
+
+    def i_want_to_be(self):
+        age = 44
+
+        if (age > 40):
+            print("I want to be forever young!")
+  
+
+  funcao_indentada_errado()
+
+forever = ForeverYoung()
+forever.i_want_to_be()


### PR DESCRIPTION
# Mudanças

Esse PR adiciona os tokens `INDENT`, `DEDENT` e `INDENTATION_ERROR` para tratar a indentação do chocopy, e também implementa a lógica associada ao reconhecimento de blocos lógicos, isto é, o início e o fim dos blocos, marcados pelos dois primeiros tokens.

# Validação

Compare essa imagem com o arquivo de teste adicionado neste PR.

![image](https://github.com/user-attachments/assets/5241b49a-b50e-45f5-9bbb-0d4168775594)
