### PR TITLE
Correção do match do integer literal

### DIFF
--- a/src/main/cup/chocopy/pa1/ChocoPy.cup
+++ b/src/main/cup/chocopy/pa1/ChocoPy.cup
@@ -300,10 +300,7 @@ binary_expr ::= expr:e1 bin_op:op expr:e2
 literal ::= NONE:n {: RESULT = new NoneLiteral(nxleft, nxright);:}
         | TRUE:t {: RESULT = new BooleanLiteral(txleft, txright, true);:}
         | FALSE:f {:  RESULT = new BooleanLiteral(fxleft, fxright, false);:}
-        | INTEGER:i {:  
-                        int integer = Integer.parseInt(i);
-                        RESULT = new IntegerLiteral(ixleft, ixright, integer); 
-                    :}
+        | INTEGER_LITERAL:i {: RESULT = new IntegerLiteral(ixleft, ixright, i); :}
         | IDSTRING:is {:  RESULT = new StringLiteral(isxleft, isxright, is); :}
         | STRING:s {:  RESULT = new StringLiteral(sxleft, sxright, s); :}
         ;


### PR DESCRIPTION
## Mudanças

Esse PR corrige a definição do literal para o caso do inteiro, alterando o `INTEGER` para o nome real que foi definido. Além disso, remove a conversão duplicada.

## Validação

![image](https://github.com/user-attachments/assets/2fb1c010-d652-42a1-b444-046ffd0551df)
 