### PR TITLE
Declarações de escopo de variável

### DIFF
--- a/src/main/cup/chocopy/pa1/ChocoPy.cup
+++ b/src/main/cup/chocopy/pa1/ChocoPy.cup
@@ -236,6 +236,8 @@ non terminal String            bin_op;
 non terminal TypeAnnotation    type;
 non terminal TypedVar          typed_var;
 non terminal VarDef            var_def;
+non terminal GlobalDecl        global_decl;
+non terminal NonLocalDecl      nonlocal_decl;
 
 /* Precedences (lowest to highest) for resolving what would otherwise be
  * ambiguities in the form of shift/reduce conflicts.. */

--- a/src/main/cup/chocopy/pa1/ChocoPy.cup
+++ b/src/main/cup/chocopy/pa1/ChocoPy.cup
@@ -269,6 +269,16 @@ program_head ::= /* not implemented; currently matches empty string */
                                      {: RESULT = empty(); :}
                 ;
 
+global_decl ::= GLOBAL:global IDENTIFIER:id_label NEWLINE {: 
+                                                        Identifier id = new Identifier(id_labelxleft, id_labelxright, id_label);
+                                                        RESULT = new GlobalDecl(globalxleft, id_labelxright, id); 
+                                                    :};
+
+nonlocal_decl ::= NONLOCAL:nonlocal IDENTIFIER:id_label NEWLINE {: 
+                                                        Identifier id = new Identifier(id_labelxleft, id_labelxright, id_label);
+                                                        RESULT = new NonLocalDecl(nonlocalxleft, id_labelxright, id); 
+                                                    :};
+
 var_def ::= typed_var:t_var ASSIGN:assign literal:value NEWLINE:n {: 
                                                                 RESULT = new VarDef(t_varxleft, valuexright, t_var, value);
                                                             :};

--- a/src/test/data/pa1/own_tests/global_decl.py
+++ b/src/test/data/pa1/own_tests/global_decl.py
@@ -1,1 +1,1 @@
-nonlocal global_variable
+global global_variable

--- a/src/test/data/pa1/own_tests/global_decl.py
+++ b/src/test/data/pa1/own_tests/global_decl.py
@@ -1,0 +1,1 @@
+nonlocal global_variable

--- a/src/test/data/pa1/own_tests/nonlocal_decl.py
+++ b/src/test/data/pa1/own_tests/nonlocal_decl.py
@@ -1,0 +1,1 @@
+nonlocal nonlocal_variable


### PR DESCRIPTION
## Mudanças

Esse PR implementa as regras associadas a declaração de escopo de variáveis.

## Validações

Compare essa imagem com o global_decl.py

![image](https://github.com/user-attachments/assets/f883e2c9-7101-486f-b4a3-f03dabfaf8e2)

Compare essa imagem com o nonlocal_decl.py

![image](https://github.com/user-attachments/assets/62819dae-cf63-4ba3-93e5-83652061e80d)
